### PR TITLE
fix: fix type mismatch error for minute column in import_ghcn_hourly

### DIFF
--- a/R/import_ghcn_hourly.R
+++ b/R/import_ghcn_hourly.R
@@ -568,6 +568,7 @@ import_single_ghcn_site <- function(
       dplyr::across(
         dplyr::any_of(
           c(
+            "minute",
             "latitude",
             "longitude",
             "elevation",

--- a/man/worldmet-package.Rd
+++ b/man/worldmet-package.Rd
@@ -40,7 +40,7 @@ the related \code{openair} package.
 Authors:
 \itemize{
   \item David Carslaw \email{david.carslaw@york.ac.uk} (\href{https://orcid.org/0000-0003-0991-950X}{ORCID})
-  \item Jack Davison \email{jack.davison@ricardo.com} (\href{https://orcid.org/0000-0003-2653-6615}{ORCID})
+  \item Jack Davison \email{jack.davison@wsp.com} (\href{https://orcid.org/0000-0003-2653-6615}{ORCID})
 }
 
 }


### PR DESCRIPTION
Fixes a bug in `import_ghcn_hourly()` where a type mismatch on the `minute` column caused `dplyr::bind_rows()` to fail when downloading multiple years.

Fixes #67 